### PR TITLE
Allow optional block to wrap getter method

### DIFF
--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -73,7 +73,8 @@ module EncryptAttributes
       define_method(name) do
         encrypted = send("encrypted_#{name}")
         secret_key = options[:secret_key].is_a?(Symbol) ? self.send(options[:secret_key]) : options[:secret_key]
-        EncryptAttributes.decrypt_attribute(encrypted, secret_key, encryption_options_for(name))
+        value = EncryptAttributes.decrypt_attribute(encrypted, secret_key, encryption_options_for(name))
+        block_given? ? yield(value) : value
       end
 
       define_method("#{name}=") do |val|

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -6,13 +6,17 @@ class Target
                 :encrypted_serialized,
                 :encrypted_encoded,
                 :encrypted_serialized_encoded,
-                :encrypted_dynamic_key
+                :encrypted_dynamic_key,
+                :encrypted_wrapped_foo
 
   encrypted_attribute :foo, secret_key: 'secretkey'
   encrypted_attribute :serialized, secret_key: 'secretkey', serialize: true
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
   encrypted_attribute :dynamic_key, secret_key: :dynamic_secret_key
+  encrypted_attribute :wrapped_foo, secret_key: 'secretkey' do |value|
+    value + "bar"
+  end
 
   def dynamic_secret_key
     "foobar"
@@ -68,6 +72,14 @@ describe EncryptAttributes do
       target.serialized_encoded = value
       expect(target.encrypted_serialized_encoded).to be_instance_of String
       expect(target.serialized_encoded).to eq value
+    end
+  end
+
+  context 'when block is passed' do
+    it 'wraps return value in block' do
+      value = 'foo'
+      target.wrapped_foo = value
+      expect(target.wrapped_foo).to eq("#{value}bar")
     end
   end
 end


### PR DESCRIPTION
I have a use-case where I'd like to easily wrap the getter method with a class, but no easy way to do it. This is easy to add but not quite sure it's the best direction.

So it would look something like this (for example):

```ruby
encrypted_attribute :payload, serialize: true, secret_key: ENV['SECRET'] do |value|
  Payload.new(value)
end
```

After decrypting and deserializing `payload`, it would pass it to the block which returns the actual value.

@k2nr any thoughts? I originally had an optional `wrapper_method` but then a block seemed sort of natural.