### PR TITLE
Create option for serialized accessors

### DIFF
--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -50,7 +50,7 @@ module EncryptAttributes
           end
 
           define_method("#{accessor_name}=") do |val|
-            send("#{name}=", { "#{accessor}": val })
+            send("#{name}=", (send(name) || {}).merge!({ accessor.to_sym => val }))
           end
         end
       end

--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -39,6 +39,21 @@ module EncryptAttributes
         value = send(name)
         value.respond_to?(:empty?) ? !value.empty? : !!value
       end
+
+      # Define methods using serialized accessors option
+      if options[:serialize].is_a?(Hash) && options[:serialize].has_key?(:accessors) && options[:serialize][:accessors].is_a?(Array)
+        options[:serialize][:accessors].map(&:to_sym).each do |accessor|
+          accessor_name = "#{name}_#{accessor}"
+
+          define_method(accessor_name) do
+            send(name)[accessor]
+          end
+
+          define_method("#{accessor_name}=") do |val|
+            send("#{name}=", { "#{accessor}": val })
+          end
+        end
+      end
     end
   end
 

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -6,13 +6,15 @@ class Target
                 :encrypted_serialized,
                 :encrypted_encoded,
                 :encrypted_serialized_encoded,
-                :encrypted_dynamic_key
+                :encrypted_dynamic_key,
+                :encrypted_create_accessors
 
   encrypted_attribute :foo, secret_key: 'secretkey'
   encrypted_attribute :serialized, secret_key: 'secretkey', serialize: true
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
   encrypted_attribute :dynamic_key, secret_key: :dynamic_secret_key
+  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute] }
 
   def dynamic_secret_key
     "foobar"
@@ -68,6 +70,15 @@ describe EncryptAttributes do
       target.serialized_encoded = value
       expect(target.encrypted_serialized_encoded).to be_instance_of String
       expect(target.serialized_encoded).to eq value
+    end
+  end
+
+  context 'when :accessors option is specified in :serialize option' do
+    it 'creates accessors' do
+      value = 'あいうえお'
+      target.create_accessors_attribute = value
+      expect(target.create_accessors).to eq ({ attribute: value })
+      expect(target.create_accessors_attribute).to eq value
     end
   end
 end

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -14,7 +14,7 @@ class Target
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
   encrypted_attribute :dynamic_key, secret_key: :dynamic_secret_key
-  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute] }
+  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute1, :attribute2] }
 
   def dynamic_secret_key
     "foobar"
@@ -76,9 +76,16 @@ describe EncryptAttributes do
   context 'when :accessors option is specified in :serialize option' do
     it 'creates accessors' do
       value = 'あいうえお'
-      target.create_accessors_attribute = value
-      expect(target.create_accessors).to eq ({ attribute: value })
-      expect(target.create_accessors_attribute).to eq value
+
+      target.create_accessors_attribute1 = value
+      expect(target.create_accessors).to eq ({ attribute1: value })
+      expect(target.create_accessors_attribute1).to eq value
+
+      target.create_accessors_attribute2 = "foo"
+      expect(target.create_accessors).to eq ({ attribute1: value, attribute2: "foo" })
+
+      target.create_accessors_attribute2 = "baz"
+      expect(target.create_accessors).to eq ({ attribute1: value, attribute2: "baz" })
     end
   end
 end


### PR DESCRIPTION
I created option for serialized accessors.
If use this option, this option makes accessors for serialized Hash's value directly like:

```rb
class Target
  include EncryptAttributes
  attr_accessor :encrypted_create_accessors

  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute] }
end

target = Target.new

target.create_accessors = { attribute: "value" }
puts target.create_accessors # => { attribute: "value" }

target.create_accessors_attribute = "value2"
puts target.create_accessors_attribute # => "value2"
puts target.create_accessors # => { attribute: "value2" }
```