### PR TITLE
Allow to use string key in accessors option's Hash

### DIFF
--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -21,7 +21,7 @@ module EncryptAttributes
     end
 
     def encrypted_attribute(name, options={})
-      encryption_targets[name.to_sym] = default_encryption_options.merge options
+      encryption_targets[name.to_s] = default_encryption_options.merge options
 
       define_method(name) do
         encrypted = send("encrypted_#{name}")
@@ -42,7 +42,7 @@ module EncryptAttributes
 
       # Define methods using serialized accessors option
       if options[:serialize].is_a?(Hash) && options[:serialize].has_key?(:accessors) && options[:serialize][:accessors].is_a?(Array)
-        options[:serialize][:accessors].map(&:to_sym).each do |accessor|
+        options[:serialize][:accessors].map(&:to_s).each do |accessor|
           accessor_name = "#{name}_#{accessor}"
 
           define_method(accessor_name) do
@@ -50,7 +50,7 @@ module EncryptAttributes
           end
 
           define_method("#{accessor_name}=") do |val|
-            send("#{name}=", (send(name) || {}).merge!({ accessor.to_sym => val }))
+            send("#{name}=", (send(name) || {}).merge!({ accessor.to_s => val }))
           end
         end
       end
@@ -64,6 +64,6 @@ module EncryptAttributes
   end
 
   def encryption_options_for(attr_name)
-    encryption_targets[attr_name.to_sym]
+    encryption_targets[attr_name.to_s]
   end
 end

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -14,7 +14,7 @@ class Target
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
   encrypted_attribute :dynamic_key, secret_key: :dynamic_secret_key
-  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute1, :attribute2] }
+  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute1, "attribute2"] }
 
   def dynamic_secret_key
     "foobar"
@@ -80,14 +80,14 @@ describe EncryptAttributes do
       value = 'あいうえお'
 
       target.create_accessors_attribute1 = value
-      expect(target.create_accessors).to eq ({ attribute1: value })
+      expect(target.create_accessors).to eq ({ "attribute1" => value })
       expect(target.create_accessors_attribute1).to eq value
 
       target.create_accessors_attribute2 = "foo"
-      expect(target.create_accessors).to eq ({ attribute1: value, attribute2: "foo" })
+      expect(target.create_accessors).to eq ({ "attribute1" => value, "attribute2" => "foo" })
 
       target.create_accessors_attribute2 = "baz"
-      expect(target.create_accessors).to eq ({ attribute1: value, attribute2: "baz" })
+      expect(target.create_accessors).to eq ({ "attribute1" => value, "attribute2" => "baz" })
     end
   end
 end


### PR DESCRIPTION
The accessors option can't be use `String`'s key.
The key will be unify to `Symbol` internally.

This PR allows to use `String`'s key in accessors option's Hash.

```rb
class Target
  include EncryptAttributes
  attr_accessor :encrypted_create_accessors

  encrypted_attribute :create_accessors, secret_key: 'secretkey', serialize: { accessors: [:attribute1, "attribute2"] }
end

target = Target.new

value = 'あいうえお'

target.create_accessors_attribute1 = value
target.create_accessors_attribute2 = value
puts target.create_accessors # { :attribute1 => "あいうえお", "attribute2" => "あいうえお" }

```