### PR TITLE
Use EncryptAttributes::Encrypt::AES class instead of Gibberish

### DIFF
--- a/encrypt_attributes.gemspec
+++ b/encrypt_attributes.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "gibberish", "~> 1.4.0"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -1,7 +1,9 @@
 require "encrypt_attributes/version"
 require "encrypt_attributes/attribute"
+require "encrypt_attributes/encrypt/aes"
 require 'yaml'
 require 'base64'
+require 'openssl'
 require 'gibberish'
 require 'active_support'
 

--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -4,7 +4,6 @@ require "encrypt_attributes/encrypt/aes"
 require 'yaml'
 require 'base64'
 require 'openssl'
-require 'gibberish'
 require 'active_support'
 
 module EncryptAttributes

--- a/lib/encrypt_attributes/attribute.rb
+++ b/lib/encrypt_attributes/attribute.rb
@@ -13,13 +13,13 @@ module EncryptAttributes
 
       # Gibberish's default encryption mode is aes-256-cbc
       # salt and iv(initialization vector) is automatically generated and embedded in encrypted @value
-      Gibberish::AES.new(@secret_key).encrypt(value)
+      Encrypt::AES.new(@secret_key).encrypt(value)
     end
 
     def decrypt
       return nil if @value.nil?
 
-      decrypted = Gibberish::AES.new(@secret_key).decrypt(@value)
+      decrypted = Encrypt::AES.new(@secret_key).decrypt(@value)
       decrypted = decode(decrypted)      if @options[:encode]
       decrypted = deserialize(decrypted) if @options[:serialize]
 

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -10,7 +10,6 @@ module EncryptAttributes
         @cipher.encrypt
         salt = generate_salt
         @cipher.pkcs5_keyivgen(@password, salt)
-
         e = @cipher.update(data) + @cipher.final
         e = "Salted__#{salt}#{e}" #OpenSSL compatible
         Base64.encode64(e)
@@ -23,14 +22,13 @@ module EncryptAttributes
 
         @cipher.pkcs5_keyivgen(@password, salt)
         @cipher.decrypt
-
         @cipher.update(data) + @cipher.final
       end
 
       private
 
       def generate_salt
-        salt = 8.times.map { rand(255).chr }.join
+        8.times.map { rand(255).chr }.join
       end
     end
   end

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -1,0 +1,37 @@
+module EncryptAttributes
+  module Encrypt
+    class AES
+      def initialize(password)
+        @password = password
+        @cipher = OpenSSL::Cipher.new("aes-256-cbc")
+      end
+
+      def encrypt(data)
+        @cipher.encrypt
+        salt = generate_salt
+        @cipher.pkcs5_keyivgen(@password, salt)
+
+        e = @cipher.update(data) + @cipher.final
+        e = "Salted__#{salt}#{e}" #OpenSSL compatible
+        Base64.encode64(e)
+      end
+
+      def decrypt(data)
+        data = Base64.decode64(data)
+        salt = data[8..15]
+        data = data[16..-1]
+
+        @cipher.pkcs5_keyivgen(@password, salt)
+        @cipher.decrypt
+
+        @cipher.update(data) + @cipher.final
+      end
+
+      private
+
+      def generate_salt
+        salt = 8.times.map { rand(255).chr }.join
+      end
+    end
+  end
+end

--- a/spec/encrypt/aes_spec.rb
+++ b/spec/encrypt/aes_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe EncryptAttributes::Encrypt::AES do
+  let(:password) { "password" }
+  let(:data) { "data" }
+  let(:encrypted_data) { "U2FsdGVkX19hYmNkZWZnaE67bR8AgXL/LM+fnAQ/GVg=\n" }
+
+  subject { EncryptAttributes::Encrypt::AES.new(password) }
+
+  describe "#encrypt" do
+    before do
+      allow(subject).to receive(:generate_salt) { "abcdefgh" }
+    end
+
+    it { expect(subject.encrypt(data)).to eq encrypted_data }
+  end
+
+  describe "#decrypt" do
+    it { expect(subject.decrypt(encrypted_data)).to eq data }
+  end
+end


### PR DESCRIPTION
Gibberish gem looks inactive and they doesn't fix deprecation warnings.
(https://github.com/mdp/gibberish/blob/master/lib/gibberish/aes.rb#L222 `OpenSSL::Cipher::Cipher` is output deprecation warning in Ruby 2.4.1)

I replaced the gem to tiny class `EncryptAttributes::Encrypt::AES`.

The code was almost extracted Gibberish's classes.
https://github.com/mdp/gibberish/blob/master/lib/gibberish/aes.rb#L207-L242