### PR TITLE
Add num argument for OpenSSL::Cupher#pkcs5_keyivgen

### DIFF
--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -9,7 +9,7 @@ module EncryptAttributes
       def encrypt(data)
         @cipher.encrypt
         salt = generate_salt
-        @cipher.pkcs5_keyivgen(@password, salt)
+        @cipher.pkcs5_keyivgen(@password, salt, 1)
         e = @cipher.update(data) + @cipher.final
         e = "Salted__#{salt}#{e}" #OpenSSL compatible
         Base64.encode64(e)
@@ -20,7 +20,7 @@ module EncryptAttributes
         salt = data[8..15]
         data = data[16..-1]
 
-        @cipher.pkcs5_keyivgen(@password, salt)
+        @cipher.pkcs5_keyivgen(@password, salt, 1)
         @cipher.decrypt
         @cipher.update(data) + @cipher.final
       end

--- a/spec/encrypt/aes_spec.rb
+++ b/spec/encrypt/aes_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe EncryptAttributes::Encrypt::AES do
   let(:password) { "password" }
   let(:data) { "data" }
-  let(:encrypted_data) { "U2FsdGVkX19hYmNkZWZnaE67bR8AgXL/LM+fnAQ/GVg=\n" }
+  let(:encrypted_data) { "U2FsdGVkX19hYmNkZWZnaNP1CILqdQwlmuFn9x/Yr9s=\n" }
 
   subject { EncryptAttributes::Encrypt::AES.new(password) }
 


### PR DESCRIPTION
Oops... I needed the `num` argument.

See https://github.com/mdp/gibberish/blob/master/lib/gibberish/aes.rb#L308 for ref.