### PR TITLE
Option to disallow blank value getting encrypted

### DIFF
--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -18,7 +18,7 @@ module EncryptAttributes
       {
         encode: false,
         serialize: false,
-        allow_blank: true
+        allow_empty: true
       }
     end
 

--- a/lib/encrypt_attributes.rb
+++ b/lib/encrypt_attributes.rb
@@ -17,7 +17,8 @@ module EncryptAttributes
     def default_encryption_options
       {
         encode: false,
-        serialize: false
+        serialize: false,
+        allow_blank: true
       }
     end
 

--- a/lib/encrypt_attributes/attribute.rb
+++ b/lib/encrypt_attributes/attribute.rb
@@ -5,7 +5,7 @@ module EncryptAttributes
     end
 
     def encrypt
-      return @value unless not_empty?(@value)
+      return @value if @value.nil? || (!@options[:allow_empty] && @value.empty?)
       value = @value
 
       value = serialize(value) if @options[:serialize]
@@ -17,7 +17,7 @@ module EncryptAttributes
     end
 
     def decrypt
-      return @value unless not_empty?(@value)
+      return @value if @value.nil? || (!@options[:allow_empty] && @value.empty?)
 
       decrypted = Encrypt::AES.new(@secret_key).decrypt(@value)
       decrypted = decode(decrypted)      if @options[:encode]
@@ -43,11 +43,6 @@ module EncryptAttributes
     def decode(s)
       decoded = Base64.decode64(s)
       decoded.encode('UTF-8', 'UTF-8')
-    end
-
-    # https://github.com/attr-encrypted/attr_encrypted/blob/a185caba554df8a17b8de205030a3ba033529a82/lib/attr_encrypted.rb#L274-L276
-    def not_empty?(value)
-      @options[:allow_blank] && !value.nil? && !(value.is_a?(String) && value.empty?)
     end
   end
 end

--- a/lib/encrypt_attributes/attribute.rb
+++ b/lib/encrypt_attributes/attribute.rb
@@ -5,7 +5,7 @@ module EncryptAttributes
     end
 
     def encrypt
-      return nil if @value.nil?
+      return @value unless not_empty?(@value)
       value = @value
 
       value = serialize(value) if @options[:serialize]
@@ -17,7 +17,7 @@ module EncryptAttributes
     end
 
     def decrypt
-      return nil if @value.nil?
+      return @value unless not_empty?(@value)
 
       decrypted = Encrypt::AES.new(@secret_key).decrypt(@value)
       decrypted = decode(decrypted)      if @options[:encode]
@@ -43,6 +43,11 @@ module EncryptAttributes
     def decode(s)
       decoded = Base64.decode64(s)
       decoded.encode('UTF-8', 'UTF-8')
+    end
+
+    # https://github.com/attr-encrypted/attr_encrypted/blob/a185caba554df8a17b8de205030a3ba033529a82/lib/attr_encrypted.rb#L274-L276
+    def not_empty?(value)
+      @options[:allow_blank] && !value.nil? && !(value.is_a?(String) && value.empty?)
     end
   end
 end

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 class Target
   include EncryptAttributes
   attr_accessor :encrypted_foo,
+                :encrypted_blank,
                 :encrypted_serialized,
                 :encrypted_encoded,
                 :encrypted_serialized_encoded,
@@ -10,6 +11,7 @@ class Target
                 :encrypted_create_accessors
 
   encrypted_attribute :foo, secret_key: 'secretkey'
+  encrypted_attribute :blank, secret_key: 'secretkey', allow_blank: false
   encrypted_attribute :serialized, secret_key: 'secretkey', serialize: true
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
@@ -35,6 +37,22 @@ describe EncryptAttributes do
     target.foo = value
     expect(target.encrypted_foo).to be_instance_of String
     expect(target.foo).to eq value
+  end
+
+  context "when :allow_blank options is specified" do
+    it "returns value when nil" do
+      value =  nil
+      target.blank = value
+      expect(target.encrypted_blank).to be_instance_of NilClass
+      expect(target.blank).to eq value
+    end
+
+    it "returns value when empty" do
+      value =  ''
+      target.blank = value
+      expect(target.encrypted_blank).to be_instance_of String
+      expect(target.blank).to eq value
+    end
   end
 
   context "when secret_key options is a symbol" do

--- a/spec/encrypt_attributes_spec.rb
+++ b/spec/encrypt_attributes_spec.rb
@@ -11,7 +11,7 @@ class Target
                 :encrypted_create_accessors
 
   encrypted_attribute :foo, secret_key: 'secretkey'
-  encrypted_attribute :blank, secret_key: 'secretkey', allow_blank: false
+  encrypted_attribute :blank, secret_key: 'secretkey', allow_empty: false
   encrypted_attribute :serialized, secret_key: 'secretkey', serialize: true
   encrypted_attribute :encoded, secret_key: 'secretkey', encode: true
   encrypted_attribute :serialized_encoded, secret_key: 'secretkey', encode: true, serialize: true
@@ -39,7 +39,7 @@ describe EncryptAttributes do
     expect(target.foo).to eq value
   end
 
-  context "when :allow_blank options is specified" do
+  context "when :allow_empty options is specified" do
     it "returns value when nil" do
       value =  nil
       target.blank = value
@@ -50,8 +50,22 @@ describe EncryptAttributes do
     it "returns value when empty" do
       value =  ''
       target.blank = value
-      expect(target.encrypted_blank).to be_instance_of String
+      expect(target.encrypted_blank).to eq value
       expect(target.blank).to eq value
+    end
+  end
+
+  context "when :allow_empty options is not specified" do
+    it "returns value when nil" do
+      value =  nil
+      target.foo = value
+      expect(target.encrypted_foo).to be_instance_of NilClass
+      expect(target.foo).to eq value
+    end
+
+    it "error when empty" do
+      value =  ''
+      expect{target.foo=value}.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
**Fixes** https://github.com/degica/hats/issues/3859
When update webhook with empty secret token, raise ``ArgumentError: data must not be empty error.

There is an issue with validations on a attribute that is to be encrypted. If it is an empty string `OpenSSL::Cipher` will raise and `ArguementError`.

I took the approach of https://github.com/attr-encrypted/attr_encrypted#the-allow_empty_value-option by adding a new option toggle. Maybe in our case we should just never allow empty strings at all since our AES algorithm does not handle them.

**Use in hats**: https://github.com/degica/hats/pull/3863