### PR TITLE
handle nil in encrypt function

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/encrypt_attributes.gemspec
+++ b/encrypt_attributes.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.2.20"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -20,6 +20,8 @@ module EncryptAttributes
         salt = data[8..15]
         data = data[16..-1]
 
+        return nil if data.nil?
+
         @cipher.pkcs5_keyivgen(@password, salt, 1)
         @cipher.decrypt
         @cipher.update(data) + @cipher.final

--- a/spec/encrypt/aes_spec.rb
+++ b/spec/encrypt/aes_spec.rb
@@ -17,5 +17,6 @@ describe EncryptAttributes::Encrypt::AES do
 
   describe "#decrypt" do
     it { expect(subject.decrypt(encrypted_data)).to eq data }
+    it { expect(subject.decrypt('')).to eq nil }
   end
 end


### PR DESCRIPTION
Fixes https://github.com/degica/encrypt_attributes/issues/12

We have a difficulty in a client which uses this library where we had data extracted from the db and passed to this code, only for it to throw an unexpected type exception. This was because the library cannot handle `nil` as an input.

When on this line, data is `nil`

https://github.com/degica/encrypt_attributes/blob/563141ded421e223c5f61d20e3289dad7c6e3aa9/lib/encrypt_attributes/encrypt/aes.rb#L25

It throws a `TypeError: no implicit conversion of nil into String`, which makes sense in this context but is cryptic in the client application.


## How to test.
please check the code 