### PR TITLE
Use GCM instead of CBC; backwards compatible with old CBC ciphertexts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,13 +17,18 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        versions:
+        - ruby: '2.7'
+        - ruby: '3.0'
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: ${{ matrix.versions.ruby }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/encrypt_attributes.gemspec
+++ b/encrypt_attributes.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
+  spec.required_ruby_version = '>= 2.7'
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -6,17 +6,17 @@ module EncryptAttributes
         @cipher = OpenSSL::Cipher.new("aes-256-cbc")
       end
 
-      def encrypt(data)
+      def encrypt(plaintext)
         @cipher.encrypt
         salt = generate_salt
         @cipher.pkcs5_keyivgen(@password, salt, 1)
-        e = @cipher.update(data) + @cipher.final
-        e = "Salted__#{salt}#{e}" #OpenSSL compatible
+        e = @cipher.update(plaintext) + @cipher.final
+        e = "Salted__#{salt}#{e}" # OpenSSL compatible
         Base64.encode64(e)
       end
 
-      def decrypt(data)
-        data = Base64.decode64(data)
+      def decrypt(ciphertext)
+        data = Base64.decode64(ciphertext)
         salt = data[8..15]
         data = data[16..-1]
 

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -29,6 +29,8 @@ module EncryptAttributes
       end
 
       def decrypt_legacy(b64_ciphertext)
+        raise 'Unsupported in Ruby >= 3.0' if RUBY_VERSION.to_f >= 3.0
+
         cipher = OpenSSL::Cipher.new('aes-256-cbc')
         data = Base64.decode64(b64_ciphertext)
         salt = data[8..15]

--- a/lib/encrypt_attributes/encrypt/aes.rb
+++ b/lib/encrypt_attributes/encrypt/aes.rb
@@ -1,36 +1,74 @@
 module EncryptAttributes
   module Encrypt
     class AES
+      AUTH_TAG_LEN = 16
+
       def initialize(password)
         @password = password
-        @cipher = OpenSSL::Cipher.new("aes-256-cbc")
       end
 
       def encrypt(plaintext)
-        @cipher.encrypt
-        salt = generate_salt
-        @cipher.pkcs5_keyivgen(@password, salt, 1)
-        e = @cipher.update(plaintext) + @cipher.final
-        e = "Salted__#{salt}#{e}" # OpenSSL compatible
-        Base64.encode64(e)
+        cipher = OpenSSL::Cipher.new('aes-256-gcm')
+        cipher.encrypt
+
+        iv = cipher.random_iv
+        salt = OpenSSL::Random.random_bytes(cipher.key_len)
+        cipher.key = v1_key(cipher, salt)
+
+        ciphertext = cipher.update(plaintext) + cipher.final
+        auth_tag = cipher.auth_tag
+        'v1|' + Base64.encode64("#{iv}#{salt}#{auth_tag}#{ciphertext}")
       end
 
-      def decrypt(ciphertext)
-        data = Base64.decode64(ciphertext)
+      def decrypt(value)
+        case value.split('|')
+        in ['v1', ciphertext] then decrypt_v1(ciphertext)
+        in [ciphertext] then decrypt_legacy(ciphertext)
+        else nil
+        end
+      end
+
+      def decrypt_legacy(b64_ciphertext)
+        cipher = OpenSSL::Cipher.new('aes-256-cbc')
+        data = Base64.decode64(b64_ciphertext)
         salt = data[8..15]
         data = data[16..-1]
 
         return nil if data.nil?
 
-        @cipher.pkcs5_keyivgen(@password, salt, 1)
-        @cipher.decrypt
-        @cipher.update(data) + @cipher.final
+        cipher.pkcs5_keyivgen(@password, salt, 1)
+        cipher.decrypt
+        cipher.update(data) + cipher.final
+      end
+
+      def decrypt_v1(b64_ciphertext)
+        cipher = OpenSSL::Cipher.new('aes-256-gcm')
+        cipher.decrypt
+
+        data = Base64.decode64(b64_ciphertext)
+        iv         = data[0, cipher.iv_len]
+        salt       = data[cipher.iv_len, cipher.key_len]
+        auth_tag   = data[cipher.iv_len+cipher.key_len, AUTH_TAG_LEN]
+        ciphertext = data[cipher.iv_len+cipher.key_len+AUTH_TAG_LEN..-1]
+
+        return nil if [iv, salt, ciphertext].any?(&:nil?)
+
+        cipher.iv = iv
+        cipher.key = v1_key(cipher, salt)
+        cipher.auth_tag = auth_tag
+        cipher.update(ciphertext) + cipher.final
       end
 
       private
 
-      def generate_salt
-        8.times.map { rand(255).chr }.join
+      def v1_key(cipher, salt)
+        OpenSSL::KDF.pbkdf2_hmac(
+          @password,
+          salt: salt,
+          iterations: 2000,
+          length: cipher.key_len,
+          hash: 'sha256'
+        )
       end
     end
   end

--- a/lib/encrypt_attributes/version.rb
+++ b/lib/encrypt_attributes/version.rb
@@ -1,3 +1,3 @@
 module EncryptAttributes
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/encrypt/aes_spec.rb
+++ b/spec/encrypt/aes_spec.rb
@@ -1,22 +1,41 @@
 require 'spec_helper'
 
 describe EncryptAttributes::Encrypt::AES do
-  let(:password) { "password" }
-  let(:data) { "data" }
-  let(:encrypted_data) { "U2FsdGVkX19hYmNkZWZnaNP1CILqdQwlmuFn9x/Yr9s=\n" }
+  let(:password) { 'password' }
+  let(:plaintext) { 'data' }
+  let(:legacy_ciphertext) { "U2FsdGVkX19hYmNkZWZnaNP1CILqdQwlmuFn9x/Yr9s=\n" }
+  let(:v1_ciphertext) do
+    "v1|ewxF/7WsWo1mG+iQTF1o7f+mFoa6topAm8x76rD6jzLLrJ4pNuqAw42yBtLF\nKSPTH9AvohkJoRiX68fuY+XWzw==\n"
+  end
 
   subject { EncryptAttributes::Encrypt::AES.new(password) }
 
-  describe "#encrypt" do
-    before do
-      allow(subject).to receive(:generate_salt) { "abcdefgh" }
+  describe '#encrypt' do
+    it 'returns different values each time (due to random IV and salt)' do
+      expect(subject.encrypt(plaintext)).to_not eq subject.encrypt(plaintext)
     end
 
-    it { expect(subject.encrypt(data)).to eq encrypted_data }
+    it 'prepends "v1|"' do
+      expect(subject.encrypt(plaintext)).to start_with 'v1|'
+    end
+
+    it 'generates decryptable ciphertexts' do
+      ciphertext = subject.encrypt(plaintext)
+      expect(subject.decrypt(ciphertext)).to eq plaintext
+    end
   end
 
-  describe "#decrypt" do
-    it { expect(subject.decrypt(encrypted_data)).to eq data }
-    it { expect(subject.decrypt('')).to eq nil }
+  describe '#decrypt' do
+    it 'decrypts legacy ciphertexts' do
+      expect(subject.decrypt(legacy_ciphertext)).to eq plaintext
+    end
+
+    it 'decrypts v1 ciphertexts' do
+      expect(subject.decrypt(v1_ciphertext)).to eq plaintext
+    end
+
+    it 'returns nil for empty ciphertexts' do
+      expect(subject.decrypt('')).to eq nil
+    end
   end
 end

--- a/spec/encrypt/aes_spec.rb
+++ b/spec/encrypt/aes_spec.rb
@@ -26,7 +26,10 @@ describe EncryptAttributes::Encrypt::AES do
   end
 
   describe '#decrypt' do
-    it 'decrypts legacy ciphertexts' do
+    it(
+      'decrypts legacy ciphertexts (only on Ruby 2.7)',
+      skip: ('Unsupported on Ruby 3' if RUBY_VERSION.to_f >= 3.0)
+    ) do
       expect(subject.decrypt(legacy_ciphertext)).to eq plaintext
     end
 


### PR DESCRIPTION
# Details

Fixes #14 

This PR updates the encrypt/decrypt methods to use GCM + pbkdf2. It's backward-compatible with old data. All new encryptions will use GCM and old data will continue to be readable.

CBC is old, has some side-channel attacks, and has no authentication. GCM is still the way to go as far as I know.
Additionally, the `pkcs5_keyivgen` method we were using is [deprecated](https://ruby-doc.org/stdlib-3.0.1/libdoc/openssl/rdoc/OpenSSL/Cipher.html#method-i-pkcs5_keyivgen). This library doesn't work on Ruby 3 because of it!

# Aside

[Rails 7 will come with encryption out of the box](https://tech.xing.com/how-to-encrypt-activerecord-attributes-in-rails-7-60aa7ea4711), so we might want to deprecate this whole library pretty soon. In the meantime, this change is a lot simpler and will get us running on Ruby 3.0 before Rails 7 comes out :wink: 