### PR TITLE
Loosen bundler version as dev dependency

### DIFF
--- a/encrypt_attributes.gemspec
+++ b/encrypt_attributes.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 2.2.20"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
I noticed CI failed when I opened [this PR](https://github.com/degica/encrypt_attributes/pulls?q=is%3Apr+is%3Aclosed) even though it's just updating README.md

the error can be found here
https://github.com/degica/encrypt_attributes/runs/5179522816?check_suite_focus=true

I think it's safe to loosen versions of bundler as a development dependency.