### PR TITLE
Bump rake to patch CVE

### DIFF
--- a/encrypt_attributes.gemspec
+++ b/encrypt_attributes.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
All version of rake prior to 12.3.3 are subject to a CVE, so bumping to 13 to patch it.

security vulnerability: https://github.com/degica/encrypt_attributes/security/dependabot/1